### PR TITLE
Fixes #1. Complete review and update of appledoc documentation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,17 @@ Here's a
 
 ### Running the tests
 
-Run the following at the command line:
+You can run the tests from Xcode using the standard test launching techniques (e.g. CMD-U to run all tests in the selected scheme).
+
+The remote tests use a local instance of CouchDB to test DB push and pull operations.
+You can set up a local CouchDB server with the following commands (assuming you already have homebrew setup):
+
+```
+brew install couchdb
+launchctl load /usr/local/opt/couchdb/homebrew.mxcl.couchdb.plist
+```
+
+You can also run the tests from the command line:
 
 ```
 xcodebuild -workspace CDTIncrementalStoreTest/CDTIncrementalStoreTest.xcworkspace -scheme CDTIS_iOSTests test | xcpretty -c
@@ -116,10 +126,10 @@ xcodebuild -workspace CDTIncrementalStoreTest/CDTIncrementalStoreTest.xcworkspac
 To test on a specific device you need to specify `-destination`:
 
 ```
-// iOS
+# iOS
 xcodebuild -workspace CDTIncrementalStoreTest/CDTIncrementalStoreTest.xcworkspace -scheme CDTIS_iOSTests -destination 'platform=iOS Simulator,OS=latest,name=iPhone 4S' test | xcpretty -c
 
-// Mac OS X
+# Mac OS X
 xcodebuild -workspace CDTIncrementalStoreTest/CDTIncrementalStoreTest.xcworkspace -scheme CDTIS_OSXTests -destination 'platform=OS X' test | xcpretty -c
 ```
 

--- a/Classes/common/CDTISObjectModel.h
+++ b/Classes/common/CDTISObjectModel.h
@@ -17,7 +17,7 @@
 
 #import <CoreData/CoreData.h>
 
-/**
+/*
  *  This is how I like to assert, it stops me in the debugger.
  *
  *  *Why not use exceptions?*
@@ -45,7 +45,6 @@ NSString *CDTISStringFromData(NSData *data);
 NSData *CDTISDataFromString(NSString *str);
 NSString *CDTISMakeMeta(NSString *s);
 
-NSString *const CDTISUndefinedAttributeType;
 NSString *const CDTISInteger16AttributeType;
 NSString *const CDTISInteger32AttributeType;
 NSString *const CDTISInteger64AttributeType;

--- a/Classes/common/CDTISObjectModel.m
+++ b/Classes/common/CDTISObjectModel.m
@@ -77,7 +77,6 @@ NSData *CDTISDataFromString(NSString *str)
 NSString *CDTISMakeMeta(NSString *s) { return [CDTISMeta stringByAppendingString:s]; }
 
 // encodings for floating point special values
-NSString *const CDTISUndefinedAttributeType = @"undefined";
 NSString *const CDTISInteger16AttributeType = @"int16";
 NSString *const CDTISInteger32AttributeType = @"int32";
 NSString *const CDTISInteger64AttributeType = @"int64";
@@ -102,10 +101,10 @@ static NSString *const CDTISPropertiesKey = @"properties";
 
 @implementation CDTISProperty
 
-/**
+/*
  * Defines the attribute meta data that is stored in the object.
  *
- *  @param att
+ *  @param attribute attribute description
  *
  *  @return initialized object
  */

--- a/Classes/common/CDTISReplicator.m
+++ b/Classes/common/CDTISReplicator.m
@@ -19,6 +19,8 @@
 #import "CDTIncrementalStore.h"
 #import "CDTISObjectModel.h"
 
+#import "CDTDatastore+Conflicts.h"
+
 @interface CDTISReplicator ()
 
 @property (nonatomic, strong) CDTIncrementalStore *incrementalStore;

--- a/Classes/common/CDTIncrementalStore.m
+++ b/Classes/common/CDTIncrementalStore.m
@@ -27,7 +27,7 @@
 #import "CDTISGraphviz.h"
 
 #ifdef HAS_NSBatchUpdateRequest
-/**
+/*
  *  Currently NSBatchUpdateResult does not supply setters.
  *  We replicate the definition of the object but make them readwrite.
  *  Later, we cast it back to the original class.. so far it works.
@@ -59,7 +59,7 @@
 @property (nonatomic, strong) CDTISObjectModel *objectModel;
 @property (nonatomic, strong) CDTReplicatorFactory *repFactory;
 
-/**
+/*
  *  This holds the "dot" directed graph, see [dotMe](@ref dotMe)
  */
 @property (nonatomic, strong) NSData *graph;
@@ -85,31 +85,31 @@ static NSString *const CDTISObjectModelKey = @"objectModel";
 // allows selection of different code paths
 // Use this instead of #ifdef's so the code are actually gets compiled
 
-/**
+/*
  *  If true, will simply delete the database object with no considerations
  */
 static BOOL CDTISDeleteAggresively = NO;
 
-/**
+/*
  *  The backing store will drop the document body if there is a JSON
  *  serialization error. When this happens there is no failure condition or
  *  error reported.  So we read it back and make sure the body isn't empty.
  */
 static BOOL CDTISReadItBack = YES;
 
-/**
+/*
  *  Will update the Dot graph on save request
  */
 static BOOL CDTISDotMeUpdate = NO;
 
-/**
+/*
  *  Default log level.
  *  Setting it to DDLogLevelOff does not turn it off, but will simply
  *  not adjust it.
  */
 static DDLogLevel CDTISEnableLogging = DDLogLevelOff;
 
-/**
+/*
  *  Detect if the hashes changed and update the stored object model.
  *  Turn this on if you would like to migrate objects into the same store.
  *
@@ -117,17 +117,17 @@ static DDLogLevel CDTISEnableLogging = DDLogLevelOff;
  */
 static BOOL CDTISUpdateStoredObjectModel = NO;
 
-/**
+/*
  *  Check entity version mismatches which could cause problems
  */
 static BOOL CDTISCheckEntityVersions = NO;
 
-/**
+/*
  *  Check for the exisitence of subentities that we may be ignorning
  */
 static BOOL CDTISCheckForSubEntities = NO;
 
-/**
+/*
  *	Support batch update requests.
  */
 static BOOL CDTISSupportBatchUpdates = YES;
@@ -135,7 +135,7 @@ static BOOL CDTISSupportBatchUpdates = YES;
 @implementation CDTIncrementalStore
 
 #pragma mark - Init
-/**
+/*
  *  Registers this NSPersistentStore.
  *  You must invoke this method before a custom subclass of NSPersistentStore
  *  can be loaded into a persistent store coordinator.
@@ -152,7 +152,7 @@ static BOOL CDTISSupportBatchUpdates = YES;
         CDTISSupportBatchUpdates = NO;
     }
 
-    /**
+    /*
      *  We post to:
      *  - CDTDATASTORE_LOG_CONTEXT
      *  - CDTREPLICATION_LOG_CONTEXT
@@ -187,7 +187,7 @@ static BOOL CDTISSupportBatchUpdates = YES;
 }
 
 #pragma mark - Utils
-/**
+/*
  *  Generate a unique identifier
  *
  *  @return A unique ID
@@ -197,7 +197,7 @@ static NSString *uniqueID(NSString *label)
     return [NSString stringWithFormat:@"%@-%@-%@", CDTISPrefix, label, TDCreateUUID()];
 }
 
-/**
+/*
  * It appears that CoreData will convert an NSString reference object to an
  * NSNumber if it can, so we make sure we always use a string.
  *
@@ -214,7 +214,7 @@ static NSString *uniqueID(NSString *label)
     return ref;
 }
 
-/**
+/*
  *  Checks to see if the entity hashes match
  *
  *  @param entity   The entity you want to compare
@@ -235,7 +235,7 @@ static BOOL badEntityVersion(NSEntityDescription *entity, NSDictionary *metadata
     return YES;
 }
 
-/**
+/*
  *  Checks to see if an object ID matches the metadata.
  *
  *  @param moid     Object ID
@@ -276,7 +276,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     return xform;
 }
 
-/**
+/*
  *  used for logging so we don't leach out the developer keys
  *
  *  @param url URL
@@ -291,7 +291,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
 
 #pragma mark - property encode
 
-/**
+/*
  *  Insert an NSData binary object into the "blob" store
  *
  *  @param blob  nbinary data
@@ -312,15 +312,15 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     return name;
 }
 
-/**
+/*
  *  Create a dictionary (for JSON) that encodes an attribute.
- *  The array represents a tuple of strings:
- *  * type
- *  * _optional_ information
- *  * encoded object
+ *  The dictionary contains:
+ *    * name : value entry giving the attribute name and (possibly encoded) value
+ *    * _optional_ metadata for the attribute in an entry named CDTISMakeMeta(name)
  *
  *  @param attribute The attribute
  *  @param value     The object
+ *  @param blobStore The blobStore
  *  @param error     Error
  *
  *  @return Encoded array
@@ -337,18 +337,6 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     if (!value) oops(@"no nil allowed");
 
     switch (type) {
-        case NSUndefinedAttributeType: {
-            if (error) {
-                NSString *str =
-                    [NSString localizedStringWithFormat:@"%@ attribute type: %@",
-                                                        CDTISUndefinedAttributeType, @(type)];
-                NSDictionary *ui = @{NSLocalizedDescriptionKey : str};
-                *error = [NSError errorWithDomain:CDTISErrorDomain
-                                             code:CDTISErrorUndefinedAttributeType
-                                         userInfo:ui];
-            }
-            return nil;
-        }
         case NSStringAttributeType: {
             NSString *str = value;
             return @{
@@ -378,7 +366,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
                 [self encodeBlob:data withName:name inStore:blobStore withMIMEType:mimeType];
             return @{
                 name : bytes,
-                CDTISMakeMeta(name) : @{CDTISMIMETypeKey : @"application/octet-stream"}
+                CDTISMakeMeta(name) : @{CDTISMIMETypeKey : mimeType}
             };
         }
         case NSTransformableAttributeType: {
@@ -505,23 +493,24 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
                 CDTISMakeMeta(name) : [NSDictionary dictionaryWithDictionary:meta]
             };
         }
-        default:
-            break;
-    }
-
-    if (error) {
-        NSString *str = [NSString
-            localizedStringWithFormat:@"type %@: is not of " @"NSNumber: %@ = %@", @(type),
-                                      attribute.name, NSStringFromClass([value class])];
-        *error = [NSError errorWithDomain:CDTISErrorDomain
-                                     code:CDTISErrorNaN
-                                 userInfo:@{NSLocalizedDescriptionKey : str}];
+		case NSUndefinedAttributeType:
+		default: {
+			if (error) {
+				NSString *str =
+				[NSString localizedStringWithFormat:@"Undefined attribute type: %@", @(type)];
+				NSDictionary *ui = @{NSLocalizedDescriptionKey : str};
+				*error = [NSError errorWithDomain:CDTISErrorDomain
+											 code:CDTISErrorUndefinedAttributeType
+										 userInfo:ui];
+			}
+			return nil;
+		}
     }
 
     return nil;
 }
 
-/**
+/*
  *  Encode a relation as a dictionary of strings:
  *  * entity name
  *  * ref/docID
@@ -546,7 +535,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     return ref;
 }
 
-/**
+/*
  *  Encode a complete relation, both "to-one" and "to-many"
  *
  *  @param rel   relation
@@ -580,10 +569,11 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     };
 }
 
-/**
+/*
  *  Get all the properties of a managed object and put them in a dictionary
  *
  *  @param mo managed object
+ *  @param blobStore The blobStore
  *
  *  @return dictionary
  */
@@ -613,7 +603,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
             NSRelationshipDescription *rel = prop;
             enc = [self encodeRelation:rel withValue:value error:&err];
         } else if ([prop isKindOfClass:[NSFetchedPropertyDescription class]]) {
-            /**
+            /*
              *  The incremental store should never see this, if it did it would
              * make NoSQL "views" interesting
              */
@@ -640,7 +630,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
 }
 
 #pragma mark - property decode
-/**
+/*
  *  Create an Object ID from the information decoded in
  *  [encodeRelationFromManagedObject](@ref encodeRelationFromManagedObject)
  *
@@ -663,7 +653,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     return moid;
 }
 
-/**
+/*
  *  Extract the binary object for the "blob" store
  *
  *  @param name  Key
@@ -677,11 +667,12 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     return [att dataFromAttachmentContent];
 }
 
-/**
+/*
  *  Get the object from the encoded property
  *
  *  @param name    name of object
  *  @param body    Dictionary representing the document
+ *  @param blobStore The blobStore
  *  @param context Context for the object
  *
  *  @return object or nil if no object exists
@@ -794,7 +785,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
 }
 
 #pragma mark - database methods
-/**
+/*
  *  Insert a managed object to the database
  *
  *  @param mo    Managed Object
@@ -834,7 +825,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     }
 
     if (CDTISReadItBack) {
-        /**
+        /*
          *  See CDTISReadItBack
          */
         rev = [self.datastore getDocumentWithId:newRev.docId error:&err];
@@ -849,7 +840,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     return YES;
 }
 
-/**
+/*
  *  Update existing managed object
  *
  *  @param mo    Managed Object
@@ -870,7 +861,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     return [self updateDocumentID:docID withChanges:changes entity:entity error:error];
 }
 
-/**
+/*
  *  Update existing document in the database
  *
  *  @param docID    Document ID
@@ -938,7 +929,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
         [upRev.attachments addEntriesFromDictionary:blobStore];
     }
 
-    /**
+    /*
      *  > ***Note***:
      *  >
      *  > Since the properties of the entity are being updated/modified, there is
@@ -967,7 +958,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     }
 
     if (CDTISReadItBack) {
-        /**
+        /*
          *  See CDTISReadItBack
          */
         upedRev = [self.datastore getDocumentWithId:upRev.docId error:&err];
@@ -982,12 +973,12 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     return YES;
 }
 
-/**
+/*
  *  Delete a managed object from the database
  *
  *  > ***Warning***: it is assumed that CoreData will handle any cascading
  *  > deletes that are required.
-
+ *
  *  @param mo    Managed Object
  *  @param error Error
  *
@@ -999,7 +990,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     NSManagedObjectID *moid = [mo objectID];
     NSString *docID = [self stringReferenceObjectForObjectID:moid];
 
-    /**
+    /*
      *  @See CDTISDeleteAggresively
      */
     if (CDTISDeleteAggresively) {
@@ -1023,7 +1014,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     return YES;
 }
 
-/**
+/*
  *  optLock??
  *
  *  @param mo    Managed Object
@@ -1037,6 +1028,16 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     return NO;
 }
 
+/*
+ *  Create a dictionary of values from the Document Body and Blob Store
+ *
+ *  @param body      body of document
+ *  @param blobStore blobStore attachement dictionary
+ *  @param context   context from Core Data
+ *  @param version   version
+ *
+ *  @return dictionary
+ */
 - (NSDictionary *)valuesFromDocumentBody:(NSDictionary *)body
                            withBlobStore:(NSDictionary *)blobStore
                              withContext:(NSManagedObjectContext *)context
@@ -1066,7 +1067,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     return [NSDictionary dictionaryWithDictionary:values];
 }
 
-/**
+/*
  *  Create a dictionary of values for the attributes of a Managed Object from
  *  a docId/ref.
  *
@@ -1096,7 +1097,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
                              versionPtr:version];
 }
 
-/**
+/*
  *  Initialize database
  *
  *  @param error Error
@@ -1109,7 +1110,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     NSURL *dir = [self URL];
     NSString *path = [dir path];
 
-    /**
+    /*
      *  check if the directory exists, or needs to be created
      */
     BOOL isDir;
@@ -1140,7 +1141,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
             return NO;
         }
     }
-    /**
+    /*
      * The URL we are given is actually a directory.  The backing store is
      * free to create as many files and subdirectories it needs.  So for an
      * actual name we use something constatn and vanilla.
@@ -1165,7 +1166,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
         [[CDTReplicatorFactory alloc] initWithDatastoreManager:manager];
     if (!repFactory) {
         NSString *msg = [NSString
-            stringWithFormat:@"%@: Could not create replication factory for push", CDTISType];
+            stringWithFormat:@"%@: Could not create replication factory for datastore", CDTISType];
         CDTLogError(CDTREPLICATION_LOG_CONTEXT, @"%@", msg);
         if (error) {
             NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey : msg};
@@ -1184,7 +1185,7 @@ static BOOL badObjectVersion(NSManagedObjectID *moid, NSDictionary *metadata)
     return YES;
 }
 
-/**
+/*
  *  Encode version hashes, which come to us as a dictionary of inline data
  *  objects, so we encode them as a hex string.
  *
@@ -1212,9 +1213,10 @@ static NSDictionary *encodeVersionHashes(NSDictionary *hashes)
     return omd;
 }
 
-/**
+/*
  *  Update the metaData for CoreData in our own database
  *
+ *  @param metadata metadata object
  *  @param docID The docID for the metaData object in our database
  *  @param error error
  *
@@ -1262,7 +1264,7 @@ static NSDictionary *encodeVersionHashes(NSDictionary *hashes)
     return YES;
 }
 
-/**
+/*
  *  Decode version hashes, which come to us as a dictionary of hex strings
  *  that we convert back into NSData objects.
  *
@@ -1281,7 +1283,7 @@ static NSDictionary *decodeVersionHashes(NSDictionary *hashes)
     return [NSDictionary dictionaryWithDictionary:newHashes];
 }
 
-/**
+/*
  *  We need to swizzle the hashes if they exist
  *
  *  @param storedMetaData <#storedMetaData description#>
@@ -1303,7 +1305,7 @@ NSDictionary *decodeCoreDataMeta(NSDictionary *storedMetaData)
     return [NSDictionary dictionaryWithDictionary:metadata];
 }
 
-/**
+/*
  *  Retrieve the CoreData metaData, if we do not have a copy then we create
  *  a new one.
  *
@@ -1361,7 +1363,7 @@ NSDictionary *decodeCoreDataMeta(NSDictionary *storedMetaData)
     return metaData;
 }
 
-/**
+/*
  *  Check that the metadata is still sane.
  *
  *  > *Note*: check is trivial right now
@@ -1386,13 +1388,13 @@ NSDictionary *decodeCoreDataMeta(NSDictionary *storedMetaData)
     return YES;
 }
 
-/**
+/*
  *  Our own setter for metadata
  *  Quote the docs:
  *  > Subclasses must override this property to provide storage and
  *  > persistence for the store metadata.
  *
- *  @param metadata
+ *  @param metadata metadata object
  */
 - (void)setMetadata:(NSDictionary *)metadata
 {
@@ -1503,7 +1505,7 @@ NSDictionary *decodeCoreDataMeta(NSDictionary *storedMetaData)
     return YES;
 }
 
-/**
+/*
  *  Create an array of sort descriptors for the fetch request
  *
  *  @param fetchRequest fetchRequest
@@ -1523,7 +1525,7 @@ NSDictionary *decodeCoreDataMeta(NSDictionary *storedMetaData)
     return [NSArray arrayWithArray:sds];
 }
 
-/**
+/*
  *  Ensure appropriate index is created for fetch request
  *
  *  Note: Queries can include unindexed fields.
@@ -1579,13 +1581,13 @@ NSDictionary *decodeCoreDataMeta(NSDictionary *storedMetaData)
     }
 }
 
-/**
+/*
  *  Process comparison predicates
  *
  *  The queries currently supported by the backing store are described in the query.md
  *  doc in the doc directory.
  *
- *  @param fetchRequest
+ *  @param cp a comparison predicate to be converted to a predicate dictionary
  *
  *  @return predicate dictionary
  */
@@ -1747,7 +1749,7 @@ NSString *kNorOperator = @"$nor";
     return nil;
 }
 
-/**
+/*
  *  create a query dictionary for the backing store
  *  > *Note*: the predicates are included in this dictionary
  *
@@ -1850,7 +1852,7 @@ NSString *kNorOperator = @"$nor";
               withContext:(NSManagedObjectContext *)context
                     error:(NSError **)error
 {
-    /**
+    /*
      *  The document, [Responding to Fetch
      * Requests](https://developer.apple.com/library/ios/documentation/DataManagement/Conceptual/IncrementalStorePG/ImplementationStrategy/ImplementationStrategy.html#//apple_ref/doc/uid/TP40010706-CH2-SW6),
      *  suggests that we get the entity from the fetch request.
@@ -1866,7 +1868,7 @@ NSString *kNorOperator = @"$nor";
                 NSLocalizedFailureReasonErrorKey : @"Error processing predicate for fetch request"
             };
             *error = [NSError errorWithDomain:CDTISErrorDomain
-                                         code:CDTISErrorNotSupported
+                                         code:CDTISErrorRequestNotSupported
                                      userInfo:userInfo];
         }
         return nil;
@@ -1884,8 +1886,8 @@ NSString *kNorOperator = @"$nor";
                                           fields:nil
                                             sort:sort];
 
-    NSFetchRequestResultType fetchType = [fetchRequest resultType];
-    switch (fetchType) {
+    NSFetchRequestResultType resultType = [fetchRequest resultType];
+    switch (resultType) {
         case NSManagedObjectResultType: {
             NSMutableArray *results = [NSMutableArray array];
             [result
@@ -1921,10 +1923,10 @@ NSString *kNorOperator = @"$nor";
             break;
     }
     NSString *s =
-        [NSString localizedStringWithFormat:@"Unknown request fetch type: %@", fetchRequest];
+        [NSString localizedStringWithFormat:@"Unknown fetch request result type: %d", resultType];
     if (error) {
         *error = [NSError errorWithDomain:CDTISErrorDomain
-                                     code:CDTISErrorExectueRequestFetchTypeUnkown
+                                     code:CDTISErrorResultTypeUnknown
                                  userInfo:@{NSLocalizedFailureReasonErrorKey : s}];
     }
     return nil;
@@ -2004,7 +2006,7 @@ NSString *kNorOperator = @"$nor";
                     @"Error processing predicate for batch update request"
             };
             *error = [NSError errorWithDomain:CDTISErrorDomain
-                                         code:CDTISErrorNotSupported
+                                         code:CDTISErrorRequestNotSupported
                                      userInfo:userInfo];
         }
         return nil;
@@ -2094,7 +2096,7 @@ NSString *kNorOperator = @"$nor";
     NSString *s = [NSString localizedStringWithFormat:@"Unknown request type: %@", @(requestType)];
     if (error) {
         *error = [NSError errorWithDomain:CDTISErrorDomain
-                                     code:CDTISErrorExectueRequestTypeUnkown
+                                     code:CDTISErrorRequestTypeUnknown
                                  userInfo:@{NSLocalizedFailureReasonErrorKey : s}];
     }
     return nil;
@@ -2184,7 +2186,7 @@ NSString *kNorOperator = @"$nor";
     return objectIDs;
 }
 
-/**
+/*
  *  Use the CDTISGraphviz to create a graph representation of the datastore
  *
  *  Once you have a database configured, in any form, you can simply call:

--- a/README.md
+++ b/README.md
@@ -98,9 +98,12 @@ the `CDTIncrementalStore`:
 
 ## Example Application
 
-There is an example application based on
-[Apple's iPhoneCoreDataRecipes][recipe] and can be found in this
-[git tree][gitrecipe].
+An example application with detailed instructions on how to convert
+a CoreData application to use CDTIncrementalStore can be found in this
+[GitHub repo][gitrecipe].
+The application is based on [Apple's iPhoneCoreDataRecipes][recipe] and
+illustrates standard CoreData interactions with CDTIncrementalStore as
+well as replication to a remote Cloudant datastore.
 
 ## Contributing to the project
 
@@ -133,7 +136,7 @@ These can be found in the [docs](docs) directory.
 
 [recipe]: https://developer.apple.com/library/ios/samplecode/iPhoneCoreDataRecipes/Introduction/Intro.html "iPhoneCoreDataRecipes"
 
-[gitrecipe]: http://github.com/jimix/iphonecoredatarecipes "Git Tree of iPhoneCoreDataRecipes"
+[gitrecipe]: https://github.com/mkistler/CDTIS_iPhoneCoreDataRecipes "GitHub Repo of CDTIS_iPhoneCoreDataRecipes"
 
 
 <!--  LocalWords:  CDTIncrementalStore Cloudant CDTDatastore Podfile


### PR DESCRIPTION
Added and updated documentation for the two main external classes, CDTIncrementalStore and CDTReplicator.  Also removed markup on internal methods so that these are not picked up by appledocs.
