### PR TITLE
Fixes #10.  Disable iOS 9 app transport security feature for unit tests.

### DIFF
--- a/CDTIncrementalStoreTest/apps/CDTIS_iOSAppTest/Info.plist
+++ b/CDTIncrementalStoreTest/apps/CDTIS_iOSAppTest/Info.plist
@@ -43,5 +43,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/Classes/common/CDTIncrementalStore.m
+++ b/Classes/common/CDTIncrementalStore.m
@@ -1923,7 +1923,7 @@ NSString *kNorOperator = @"$nor";
             break;
     }
     NSString *s =
-        [NSString localizedStringWithFormat:@"Unknown fetch request result type: %d", resultType];
+        [NSString localizedStringWithFormat:@"Unknown fetch request result type: %lu", (unsigned long)resultType];
     if (error) {
         *error = [NSError errorWithDomain:CDTISErrorDomain
                                      code:CDTISErrorResultTypeUnknown


### PR DESCRIPTION
Disabled app transport security and also fixed one minor warning message showing up in unit tests.
