### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,12 @@ the `CDTIncrementalStore`:
 
 ## Example Application
 
-There is an example application based on
-[Apple's iPhoneCoreDataRecipes][recipe] and can be found in this
-[git tree][gitrecipe].
+An example application with detailed instructions on how to convert
+a CoreData application to use CDTIncrementalStore can be found in this
+[GitHub repo][gitrecipe].
+The application is based on [Apple's iPhoneCoreDataRecipes][recipe] and
+illustrates standard CoreData interactions with CDTIncrementalStore as
+well as replication to a remote Cloudant datastore.
 
 ## Contributing to the project
 
@@ -133,7 +136,7 @@ These can be found in the [docs](docs) directory.
 
 [recipe]: https://developer.apple.com/library/ios/samplecode/iPhoneCoreDataRecipes/Introduction/Intro.html "iPhoneCoreDataRecipes"
 
-[gitrecipe]: http://github.com/jimix/iphonecoredatarecipes "Git Tree of iPhoneCoreDataRecipes"
+[gitrecipe]: https://github.com/mkistler/CDTIS_iPhoneCoreDataRecipes "GitHub Repo of CDTIS_iPhoneCoreDataRecipes"
 
 
 <!--  LocalWords:  CDTIncrementalStore Cloudant CDTDatastore Podfile

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ These can be found in the [docs](docs) directory.
 
 [cloudant sync]: https://github.com/cloudant/CDTDatastore "Cloudant Sync iOS datastore library"
 
-[cocoapods]: http://cocoapods.org "Cocoa Pods"
+[cocoapods]: http://cocoapods.org "CocoaPods"
 
 [bridging header]: https://developer.apple.com/library/ios/documentation/swift/conceptual/buildingcocoaapps/MixandMatch.html "Bridging Headers"
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
